### PR TITLE
Change APP_ID manifest template.  Fixes runtime GPG crash.

### DIFF
--- a/gpgs/manifests/android/AndroidManifest.xml
+++ b/gpgs/manifests/android/AndroidManifest.xml
@@ -3,6 +3,6 @@
 	package="{{android.package}}">
 	<uses-sdk android:minSdkVersion="{{android.minimum_sdk_version}}" android:targetSdkVersion="{{android.target_sdk_version}}" />
 	<application>
-		<meta-data android:name="com.google.android.gms.games.APP_ID" android:value="\ {{gpgs.app_id}}" />
+		<meta-data android:name="com.google.android.gms.games.APP_ID" android:value="\u003{{gpgs.app_id}}" />
 	</application>
 </manifest>


### PR DESCRIPTION
When I built my game today for Android (AAB), I started getting runtime crashes immediately on startup.

Logcat showed the following error message, related to the GPGS library not knowing how to trim a string apparently?  Really bizarre.

<details>

```
08-14 23:31:25.485  3836  3836 I GoogleInputMethodService: GoogleInputMethodService.onStartInput():1831
08-14 23:31:25.516 16749 16749 V threaded_app: Resume: 0x7955e7ef40
08-14 23:31:25.539 29879 16804 E PlayGamesServices[ValidateServiceOp]: ****
08-14 23:31:25.539 29879 16804 E PlayGamesServices[ValidateServiceOp]: **** APP ID IS NOT CORRECTLY CONFIGURED TO USE GOOGLE PLAY GAME SERVICES
08-14 23:31:25.539 29879 16804 E PlayGamesServices[ValidateServiceOp]: **** Application ID ( MY_NUMERIC_APP_ID) must be a numeric value.
08-14 23:31:25.539 29879 16804 E PlayGamesServices[ValidateServiceOp]: **** Please verify that your manifest refers to the correct project ID.
08-14 23:31:25.539 29879 16804 E PlayGamesServices[ValidateServiceOp]: ****
08-14 23:31:25.539 29879 16804 E PlayGamesServices[ValidateServiceOp]: **** For more information, refer to the troubleshooting guide:
08-14 23:31:25.539 29879 16804 E PlayGamesServices[ValidateServiceOp]: **** https://developers.google.com/games/services/android/troubleshooting#check_your_metadata_tags
08-14 23:31:25.539 29879 16804 E PlayGamesServices[ValidateServiceOp]: ****
--------- beginning of crash
08-14 23:31:25.541 16749 16784 E AndroidRuntime: FATAL EXCEPTION: GoogleApiHandler
08-14 23:31:25.541 16749 16784 E AndroidRuntime: Process: dev.skaterdad.applespider, PID: 16749
08-14 23:31:25.541 16749 16784 E AndroidRuntime: java.lang.IllegalStateException: A fatal developer error has occurred. Class name: zzf. Start service action: com.google.android.gms.games.service.START. Service Descriptor: com.google.android.gms.games.internal.IGamesService.
08-14 23:31:25.541 16749 16784 E AndroidRuntime:        at com.google.android.gms.common.internal.BaseGmsClient$zza.zza(Unknown Source:20)
08-14 23:31:25.541 16749 16784 E AndroidRuntime:        at com.google.android.gms.common.internal.BaseGmsClient$zzc.zzo(Unknown Source:11)
08-14 23:31:25.541 16749 16784 E AndroidRuntime:        at com.google.android.gms.common.internal.BaseGmsClient$zzb.handleMessage(Unknown Source:49)
08-14 23:31:25.541 16749 16784 E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:107)
08-14 23:31:25.541 16749 16784 E AndroidRuntime:        at com.google.android.gms.internal.common.zze.dispatchMessage(Unknown Source:7)
08-14 23:31:25.541 16749 16784 E AndroidRuntime:        at android.os.Looper.loop(Looper.java:214)
08-14 23:31:25.541 16749 16784 E AndroidRuntime:        at android.os.HandlerThread.run(HandlerThread.java:67)
08-14 23:31:25.544  1444 16805 I DropBoxManagerService: add tag=data_app_crash isTagEnabled=true flags=0x2
08-14 23:31:25.545  1444  3982 W ActivityTaskManager:   Force finishing activity dev.skaterdad.applespider/com.dynamo.android.DefoldActivity
```

</details>

I found a fix in this thread: https://github.com/playgameservices/play-games-plugin-for-unity/issues/2013

So far I have only tested with my one game, and only with AAB builds.  It seems difficult to believe that APK/AAB are that different to cause this crash?