### PR TITLE
Pass Leaderboard Id to score JSON objects

### DIFF
--- a/gpgs/src/java/com/defold/gpgs/GpgsJNI.java
+++ b/gpgs/src/java/com/defold/gpgs/GpgsJNI.java
@@ -632,7 +632,7 @@ public class GpgsJNI {
         return json;
     }
 
-    public void loadTopScores(String leaderboardId, int span, int collection, int maxResults) {
+    public void loadTopScores(final String leaderboardId, int span, int collection, int maxResults) {
         if(initLeaderboards()) {
             Task<AnnotatedData<LeaderboardsClient.LeaderboardScores>> task = mLeaderboardsClient.loadTopScores(leaderboardId, span, collection, maxResults);
             task.addOnSuccessListener(new OnSuccessListener<AnnotatedData<LeaderboardsClient.LeaderboardScores>>() {
@@ -659,7 +659,7 @@ public class GpgsJNI {
         }
     }
 
-    public void loadPlayerCenteredScores(String leaderboardId, int span, int collection, int maxResults) {
+    public void loadPlayerCenteredScores(final String leaderboardId, int span, int collection, int maxResults) {
         if(initLeaderboards()) {
             Task<AnnotatedData<LeaderboardsClient.LeaderboardScores>> task = mLeaderboardsClient.loadPlayerCenteredScores(leaderboardId, span, collection, maxResults);
             task.addOnSuccessListener(new OnSuccessListener<AnnotatedData<LeaderboardsClient.LeaderboardScores>>() {
@@ -686,7 +686,7 @@ public class GpgsJNI {
         }
     }
 
-    public void loadCurrentPlayerLeaderboardScore(String leaderboardId, int span, int collection) {
+    public void loadCurrentPlayerLeaderboardScore(final String leaderboardId, int span, int collection) {
         if(initLeaderboards()) {
             Task<AnnotatedData<LeaderboardScore>> task = mLeaderboardsClient.loadCurrentPlayerLeaderboardScore(leaderboardId, span, collection);
             task.addOnSuccessListener(new OnSuccessListener<AnnotatedData<LeaderboardScore>>() {

--- a/gpgs/src/java/com/defold/gpgs/GpgsJNI.java
+++ b/gpgs/src/java/com/defold/gpgs/GpgsJNI.java
@@ -617,8 +617,9 @@ public class GpgsJNI {
         }
     }
 
-    private static JSONObject scoreToJSON(LeaderboardScore score) throws JSONException {
+    private static JSONObject scoreToJSON(LeaderboardScore score, String leaderboardId) throws JSONException {
         JSONObject json = new JSONObject();
+        json.put("leaderboard_id", leaderboardId);
         json.put("display_rank", score.getDisplayRank());
         json.put("display_score", score.getDisplayScore());
         json.put("rank", score.getRank());
@@ -643,7 +644,7 @@ public class GpgsJNI {
                     try {
                         JSONArray result = new JSONArray();
                         for (LeaderboardScore score : buffer) {
-                            JSONObject json = scoreToJSON(score);
+                            JSONObject json = scoreToJSON(score, leaderboardId);
                             result.put(json.toString());
                         }
                         message = result.toString();
@@ -670,7 +671,7 @@ public class GpgsJNI {
                     try {
                         JSONArray result = new JSONArray();
                         for (LeaderboardScore score : buffer) {
-                            JSONObject json = scoreToJSON(score);
+                            JSONObject json = scoreToJSON(score, leaderboardId);
                             result.put(json.toString());
                         }
                         message = result.toString();
@@ -699,7 +700,7 @@ public class GpgsJNI {
                     }
                     else {
                         try {
-                            JSONObject result = scoreToJSON(score);
+                            JSONObject result = scoreToJSON(score, leaderboardId);
                             message = result.toString();
                         } catch (JSONException e) {
                             message = "{ \"error\": \"Error while converting leaderboard score to JSON: " + e.getMessage() + "\", \"status\": " + STATUS_FAILED + " }";


### PR DESCRIPTION
Hello!

I came across a use case for getting leaderboard scores, and noticed the Leaderboard ID was not part of the callback data.

This PR proposes to pass along the `String leaderboardId` with the `LeaderboardScore`, and adding a `leaderboard_id` key to the JSON object.   This allows us to know which leaderboard we're dealing with in Lua.

I've tested this on a published game with my phone.  The changes are simple, so I expect it will not have issues.

Example:
```lua

-- somewhere, querying 2 leaderboards

	gpgs.leaderboard_get_player_score(LEADERBOARD_ID, gpgs.TIME_SPAN_ALL_TIME, gpgs.COLLECTION_PUBLIC)
	gpgs.leaderboard_get_player_score(HIGHLEVEL_ID, gpgs.TIME_SPAN_ALL_TIME, gpgs.COLLECTION_PUBLIC)

-- in the callback

	elseif message_id == gpgs.MSG_GET_PLAYER_SCORE then
		if not message.error and message.score then
			local gpgs_score = tonumber(message.score)

			-- If GPGS high score > current game score, apply it!
			if message.leaderboard_id == LEADERBOARD_ID then
				if gpgs_score > savedata.stats.high_score then
					savedata.update_score(gpgs_score)
				end
			-- If GPGS high level > current game level, apply it
			elseif message.leaderboard_id == HIGHLEVEL_ID then
				if gpgs_score > savedata.stats.high_level then
					savedata.update_level(gpgs_score)
				end
			end
		end


```