### PR TITLE
Add is_supported function & change gradle deps to implementation

### DIFF
--- a/gpgs/api/gpgs.script_api
+++ b/gpgs/api/gpgs.script_api
@@ -6,6 +6,25 @@
 
 #*****************************************************************************************************
 
+  - name: is_supported
+    type: function
+    desc: Check if Google Play Services are available & ready on the device.
+
+    returns:
+      - name: is_supported
+        type: boolean
+        desc: Status of Google Play Services on the device.
+
+    examples:
+      - desc: |-
+            ```lua
+            if gpgs then
+              local is_supported = gpgs.is_supported()
+            end
+            ```
+
+#*****************************************************************************************************
+
   - name: login
     type: function
     desc: Login to GPGS using a button.

--- a/gpgs/manifests/android/build.gradle
+++ b/gpgs/manifests/android/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
 	// https://developers.google.com/android/guides/setup#split
-	compile 'com.google.android.gms:play-services-base:17.5.0'
-	compile 'com.google.android.gms:play-services-auth:18.1.0'
-	compile 'com.google.android.gms:play-services-games:20.0.1'
+	implementation 'com.google.android.gms:play-services-base:17.5.0'
+	implementation 'com.google.android.gms:play-services-auth:18.1.0'
+	implementation 'com.google.android.gms:play-services-games:20.0.1'
 }

--- a/gpgs/manifests/android/extension-gpgs.pro
+++ b/gpgs/manifests/android/extension-gpgs.pro
@@ -1,1 +1,0 @@
--keep public class com.google.android.gms.**

--- a/gpgs/manifests/android/extension-gpgs.pro
+++ b/gpgs/manifests/android/extension-gpgs.pro
@@ -1,0 +1,1 @@
+-keep public class com.google.android.gms.**

--- a/gpgs/src/gpgs_extension.cpp
+++ b/gpgs/src/gpgs_extension.cpp
@@ -28,6 +28,7 @@ struct GPGS
     jmethodID               m_getServerAuthCode;
     jmethodID               m_isLoggedIn;
     jmethodID               m_setGravityForPopups;
+    jmethodID               m_isSupported;
 };
 
 struct GPGS_Disk
@@ -315,6 +316,11 @@ static int GpgsAuth_getServerAuthCode(lua_State* L)
 static int GpgsAuth_isLoggedIn(lua_State* L)
 {
     return CallBooleanMethod(L, g_gpgs.m_GpgsJNI, g_gpgs.m_isLoggedIn);
+}
+
+static int GpgsAuth_isSupported(lua_State* L)
+{
+    return CallBooleanMethod(L, g_gpgs.m_GpgsJNI, g_gpgs.m_isSupported);
 }
 
 //******************************************************************************
@@ -745,6 +751,8 @@ JNIEXPORT void JNICALL Java_com_defold_gpgs_GpgsJNI_gpgsAddToQueue(JNIEnv * env,
 
 static const luaL_reg Gpgs_methods[] =
 {
+    //general
+    {"is_supported", GpgsAuth_isSupported},
     //authorization
     {"login", GpgsAuth_Login},
     {"logout", GpgsAuth_Logout},
@@ -860,6 +868,9 @@ static void LuaInit(lua_State* L)
 
 static void InitJNIMethods(JNIEnv* env, jclass cls)
 {
+    //general
+    g_gpgs.m_isSupported = env->GetMethodID(cls, "isSupported", "()Z");
+
     //authorization
     g_gpgs.m_silentLogin = env->GetMethodID(cls, "silentLogin", "()V");
     g_gpgs.m_login = env->GetMethodID(cls, "login", "()V");

--- a/gpgs/src/java/com/defold/gpgs/GpgsJNI.java
+++ b/gpgs/src/java/com/defold/gpgs/GpgsJNI.java
@@ -14,6 +14,8 @@ import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
 import com.google.android.gms.auth.api.signin.GoogleSignInClient;
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
 import com.google.android.gms.common.api.ApiException;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.games.Games;
 import com.google.android.gms.games.GamesClient;
 import com.google.android.gms.games.Player;
@@ -98,6 +100,7 @@ public class GpgsJNI {
     private String client_id;
     private boolean is_request_id_token;
     private boolean is_request_auth_code;
+    private boolean is_supported;
 
     //--------------------------------------------------
     // Authorization
@@ -175,6 +178,8 @@ public class GpgsJNI {
         this.client_id = client_id;
         this.is_request_auth_code = is_request_auth_code;
         this.is_request_id_token = is_request_id_token;
+
+        this.is_supported = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(activity) == ConnectionResult.SUCCESS;
 
         mGoogleSignInClient = GoogleSignIn.getClient(activity, getSignInOptions());
     }
@@ -325,6 +330,10 @@ public class GpgsJNI {
 
     public void setGravityForPopups(int gravity) {
         mGravity = gravity;
+    }
+
+    public boolean isSupported() {
+        return is_supported;
     }
 
     //--------------------------------------------------

--- a/main/menu.gui
+++ b/main/menu.gui
@@ -1141,6 +1141,68 @@ nodes {
   text_leading: 1.0
   text_tracking: 0.0
 }
+nodes {
+  position {
+    x: 977.0
+    y: 543.094
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 300.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEXT
+  blend_mode: BLEND_MODE_ALPHA
+  text: "Support Status"
+  font: "larryfont"
+  id: "support_status"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  outline {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  shadow {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  adjust_mode: ADJUST_MODE_FIT
+  line_break: true
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  outline_alpha: 1.0
+  shadow_alpha: 1.0
+  template_node_child: false
+  text_leading: 1.0
+  text_tracking: 0.0
+}
 material: "/builtins/materials/gui.material"
 adjust_reference: ADJUST_REFERENCE_PARENT
 max_nodes: 512

--- a/main/menu.gui_script
+++ b/main/menu.gui_script
@@ -17,6 +17,12 @@ local popup_positions = {
 function init(self)
     msg.post(".", "acquire_input_focus")
     self.popup_pos = 3
+
+    if gpgs and gpgs.is_supported() then
+        gui.set_text(gui.get_node("support_status"), "Is Supported")
+    else
+        gui.set_text(gui.get_node("support_status"), "Not Supported")
+    end
 end
 
 


### PR DESCRIPTION
I hope you don't mind that this PR contains 2 changes.  They are both related to fixing runtime crashes on older Android devices.

### Fix build.gradle and add proguard rules
Per the [official Android docs](https://developers.google.com/android/guides/setup), I've updated the build.gradle to use `implementation` instead of `compile`.  This allows the classes to be available at runtime, according to some blogs I've read.  

I also added a proguard rule to keep all of the gms classes.  It's unclear if it's 100% needed, but it can't hurt.

My hope is that this fixes some crashes I've been seeing in production.

### gpgs.is_supported
I fired up an old Motorola Droid RAZR M, which runs Android 4.4.2.  It has an outdated Google Play Services library, which you can see by checking the logcat output.  That only becomes a problem when you try to do things like log in, which causes Java to finally try looking for missing classes at runtime, and crashes.

Luckily the `GoogleApiAvailability` class gives you a way to test for support on the device.  I've kept it simple and returned a simple boolean.  This was recommended at the bottom of the docs page referenced before.

This seems to work well.  My Droid RAZR M returns false, and my Pixel 3A XL returns true.

### Should be ready now
I've had these commits in production for several days now, and have not seen any issues.

My old Droid RAZR finally updated itself, this this `is_supported` function picked up on it perfectly well.