### PR TITLE
Add Email and Profile Scope

### DIFF
--- a/gpgs/src/gpgs_extension.cpp
+++ b/gpgs/src/gpgs_extension.cpp
@@ -28,6 +28,7 @@ struct GPGS
     jmethodID               m_isLoggedIn;
     jmethodID               m_setGravityForPopups;
     jmethodID               m_isSupported;
+    jmethodID               m_getEmail;
 };
 
 struct GPGS_Disk
@@ -300,6 +301,11 @@ static int GpgsAuth_getDisplayName(lua_State* L)
 static int GpgsAuth_getId(lua_State* L)
 {
     return CallStringMethod(L, g_gpgs.m_GpgsJNI, g_gpgs.m_getId);
+}
+
+static int GpgsAuth_getEmail(lua_State* L)
+{
+    return CallStringMethod(L, g_gpgs.m_GpgsJNI,g_gpgs.m_getEmail);
 }
 
 static int GpgsAuth_getIdToken(lua_State* L)
@@ -757,6 +763,7 @@ static const luaL_reg Gpgs_methods[] =
     {"get_id", GpgsAuth_getId},
     {"get_id_token", GpgsAuth_getIdToken},
     {"get_server_auth_code", GpgsAuth_getServerAuthCode},
+    {"get_email", GpgsAuth_getEmail},
     {"is_logged_in", GpgsAuth_isLoggedIn},
     {"set_popup_position", GpgsAuth_setGravityForPopups},
     {"set_callback", Gpg_set_callback},
@@ -877,6 +884,7 @@ static void InitJNIMethods(JNIEnv* env, jclass cls)
     g_gpgs.m_getId = env->GetMethodID(cls, "getId", "()Ljava/lang/String;");
     g_gpgs.m_getIdToken = env->GetMethodID(cls, "getIdToken", "()Ljava/lang/String;");
     g_gpgs.m_getServerAuthCode = env->GetMethodID(cls, "getServerAuthCode", "()Ljava/lang/String;");
+    g_gpgs.m_getEmail = env->GetMethodID(cls,"getEmail","()Ljava/lang/String;");
     g_gpgs.m_setGravityForPopups = env->GetMethodID(cls, "setGravityForPopups", "(I)V");
 
     //disk
@@ -934,7 +942,7 @@ static void CheckInitializationParams(const char* client_id, bool request_server
 }
 
 
-static void InitializeJNI(const char* client_id, bool request_server_auth_code, bool request_id_token)
+static void InitializeJNI(const char* client_id, bool request_server_auth_code, bool request_id_token, bool request_email)
 {
     CheckInitializationParams(client_id, request_server_auth_code > 0, request_id_token > 0);
 
@@ -944,11 +952,11 @@ static void InitializeJNI(const char* client_id, bool request_server_auth_code, 
 
     InitJNIMethods(env, cls);
 
-    jmethodID jni_constructor = env->GetMethodID(cls, "<init>", "(Landroid/app/Activity;ZZZLjava/lang/String;)V");
+    jmethodID jni_constructor = env->GetMethodID(cls, "<init>", "(Landroid/app/Activity;ZZZZLjava/lang/String;)V");
     jstring java_client_id = env->NewStringUTF(client_id);
 
     g_gpgs.m_GpgsJNI = env->NewGlobalRef(env->NewObject(cls, jni_constructor, threadAttacher.GetActivity()->clazz,
-                                g_gpgs_disk.is_using, request_server_auth_code, request_id_token, java_client_id));
+                                g_gpgs_disk.is_using, request_server_auth_code, request_id_token, request_email, java_client_id));
 
     env->DeleteLocalRef(java_client_id);
 }
@@ -962,10 +970,12 @@ static dmExtension::Result InitializeGpgs(dmExtension::Params* params)
 
     int request_server_auth_code = dmConfigFile::GetInt(params->m_ConfigFile, "gpgs.request_server_auth_code", 0);
     int request_id_token = dmConfigFile::GetInt(params->m_ConfigFile, "gpgs.request_id_token", 0);
+    int request_email = dmConfigFile::GetInt(params->m_ConfigFile, "gpgs.request_email", 0);
+    dmLogInfo("Request Email: ", request_email)
 
     const char* client_id = dmConfigFile::GetString(params->m_ConfigFile, "gpgs.client_id", 0);
 
-    InitializeJNI(client_id, request_server_auth_code > 0, request_id_token > 0);
+    InitializeJNI(client_id, request_server_auth_code > 0, request_id_token > 0, request_email > 0);
     dmAndroid::RegisterOnActivityResultListener(OnActivityResult);
     gpgs_callback_initialize();
     return dmExtension::RESULT_OK;

--- a/gpgs/src/gpgs_extension.cpp
+++ b/gpgs/src/gpgs_extension.cpp
@@ -25,10 +25,11 @@ struct GPGS
     jmethodID               m_getId;
     jmethodID               m_getIdToken;
     jmethodID               m_getServerAuthCode;
+    jmethodID               m_getEmail;
+    jmethodID               m_getProfile;
     jmethodID               m_isLoggedIn;
     jmethodID               m_setGravityForPopups;
     jmethodID               m_isSupported;
-    jmethodID               m_getEmail;
 };
 
 struct GPGS_Disk
@@ -306,6 +307,11 @@ static int GpgsAuth_getId(lua_State* L)
 static int GpgsAuth_getEmail(lua_State* L)
 {
     return CallStringMethod(L, g_gpgs.m_GpgsJNI,g_gpgs.m_getEmail);
+}
+
+static int GpgsAuth_getProfile(lua_State* L)
+{
+    return CallStringMethod(L, g_gpgs.m_GpgsJNI,g_gpgs.m_getProfile);
 }
 
 static int GpgsAuth_getIdToken(lua_State* L)
@@ -764,6 +770,7 @@ static const luaL_reg Gpgs_methods[] =
     {"get_id_token", GpgsAuth_getIdToken},
     {"get_server_auth_code", GpgsAuth_getServerAuthCode},
     {"get_email", GpgsAuth_getEmail},
+    {"get_profile", GpgsAuth_getProfile},
     {"is_logged_in", GpgsAuth_isLoggedIn},
     {"set_popup_position", GpgsAuth_setGravityForPopups},
     {"set_callback", Gpg_set_callback},
@@ -885,6 +892,7 @@ static void InitJNIMethods(JNIEnv* env, jclass cls)
     g_gpgs.m_getIdToken = env->GetMethodID(cls, "getIdToken", "()Ljava/lang/String;");
     g_gpgs.m_getServerAuthCode = env->GetMethodID(cls, "getServerAuthCode", "()Ljava/lang/String;");
     g_gpgs.m_getEmail = env->GetMethodID(cls,"getEmail","()Ljava/lang/String;");
+    g_gpgs.m_getProfile = env->GetMethodID(cls,"getProfile","()Ljava/lang/String;");
     g_gpgs.m_setGravityForPopups = env->GetMethodID(cls, "setGravityForPopups", "(I)V");
 
     //disk
@@ -942,7 +950,7 @@ static void CheckInitializationParams(const char* client_id, bool request_server
 }
 
 
-static void InitializeJNI(const char* client_id, bool request_server_auth_code, bool request_id_token, bool request_email)
+static void InitializeJNI(const char* client_id, bool request_server_auth_code, bool request_id_token, bool request_email, bool request_profile)
 {
     CheckInitializationParams(client_id, request_server_auth_code > 0, request_id_token > 0);
 
@@ -952,11 +960,11 @@ static void InitializeJNI(const char* client_id, bool request_server_auth_code, 
 
     InitJNIMethods(env, cls);
 
-    jmethodID jni_constructor = env->GetMethodID(cls, "<init>", "(Landroid/app/Activity;ZZZZLjava/lang/String;)V");
+    jmethodID jni_constructor = env->GetMethodID(cls, "<init>", "(Landroid/app/Activity;ZZZZZLjava/lang/String;)V");
     jstring java_client_id = env->NewStringUTF(client_id);
 
     g_gpgs.m_GpgsJNI = env->NewGlobalRef(env->NewObject(cls, jni_constructor, threadAttacher.GetActivity()->clazz,
-                                g_gpgs_disk.is_using, request_server_auth_code, request_id_token, request_email, java_client_id));
+                                g_gpgs_disk.is_using, request_server_auth_code, request_id_token, request_email, request_profile, java_client_id));
 
     env->DeleteLocalRef(java_client_id);
 }
@@ -971,11 +979,11 @@ static dmExtension::Result InitializeGpgs(dmExtension::Params* params)
     int request_server_auth_code = dmConfigFile::GetInt(params->m_ConfigFile, "gpgs.request_server_auth_code", 0);
     int request_id_token = dmConfigFile::GetInt(params->m_ConfigFile, "gpgs.request_id_token", 0);
     int request_email = dmConfigFile::GetInt(params->m_ConfigFile, "gpgs.request_email", 0);
-    dmLogInfo("Request Email: ", request_email)
+    int request_profile = dmConfigFile::GetInt(params->m_ConfigFile, "gpgs.request_profile", 0);
 
     const char* client_id = dmConfigFile::GetString(params->m_ConfigFile, "gpgs.client_id", 0);
 
-    InitializeJNI(client_id, request_server_auth_code > 0, request_id_token > 0, request_email > 0);
+    InitializeJNI(client_id, request_server_auth_code > 0, request_id_token > 0, request_email > 0, request_profile > 0);
     dmAndroid::RegisterOnActivityResultListener(OnActivityResult);
     gpgs_callback_initialize();
     return dmExtension::RESULT_OK;

--- a/gpgs/src/java/com/defold/gpgs/GpgsJNI.java
+++ b/gpgs/src/java/com/defold/gpgs/GpgsJNI.java
@@ -102,6 +102,7 @@ public class GpgsJNI {
     private boolean is_request_id_token;
     private boolean is_request_auth_code;
     private boolean is_request_email;
+    private boolean is_request_profile;
     private boolean is_supported;
 
     //--------------------------------------------------
@@ -198,13 +199,14 @@ public class GpgsJNI {
         }
     }
 
-    public GpgsJNI(Activity activity, boolean is_disk_active, boolean is_request_auth_code, boolean is_request_id_token, boolean is_request_email, String client_id) {
+    public GpgsJNI(Activity activity, boolean is_disk_active, boolean is_request_auth_code, boolean is_request_id_token, boolean is_request_email, boolean is_request_profile, String client_id) {
         this.activity = activity;
         this.is_disk_active = is_disk_active;
         this.client_id = client_id;
         this.is_request_auth_code = is_request_auth_code;
         this.is_request_id_token = is_request_id_token;
         this.is_request_email = is_request_email;
+        this.is_request_profile = is_request_profile;
 
         this.is_supported = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(activity) == ConnectionResult.SUCCESS;
 
@@ -257,13 +259,31 @@ public class GpgsJNI {
             if (is_request_email) {
                 builder.requestEmail();
             }
-            
-            builder.requestProfile();
+
+            if (is_request_profile)
+            {
+                builder.requestProfile();
+            }
 
             mSignInOptions = builder.build();
         }
 
         return mSignInOptions;
+    }
+
+    private String profileToJsonString() throws JSONException {
+        JSONObject profile = new JSONObject();
+
+        profile.put("name",mSignedInAccount.getDisplayName());
+        profile.put("given_name",mSignedInAccount.getGivenName());
+        profile.put("family_name",mSignedInAccount.getFamilyName());
+        profile.put("photo_url",mSignedInAccount.getPhotoUrl());
+        profile.put("id",mSignedInAccount.getId());
+        
+        String profileText = profile.toString();
+
+        return profileText;
+
     }
 
     public void activityResult(int requestCode, int resultCode, Intent intent) {
@@ -347,6 +367,10 @@ public class GpgsJNI {
 
     public String getEmail() {
         return isLoggedIn() ? mSignedInAccount.getEmail() : null;
+    }
+
+    public String getProfile() throws JSONException{
+        return isLoggedIn() ? profileToJsonString() : null;
     }
 
     public String getIdToken() {

--- a/gpgs/src/java/com/defold/gpgs/GpgsJNI.java
+++ b/gpgs/src/java/com/defold/gpgs/GpgsJNI.java
@@ -101,6 +101,7 @@ public class GpgsJNI {
     private String client_id;
     private boolean is_request_id_token;
     private boolean is_request_auth_code;
+    private boolean is_request_email;
     private boolean is_supported;
 
     //--------------------------------------------------
@@ -197,12 +198,13 @@ public class GpgsJNI {
         }
     }
 
-    public GpgsJNI(Activity activity, boolean is_disk_active, boolean is_request_auth_code, boolean is_request_id_token, String client_id) {
+    public GpgsJNI(Activity activity, boolean is_disk_active, boolean is_request_auth_code, boolean is_request_id_token, boolean is_request_email, String client_id) {
         this.activity = activity;
         this.is_disk_active = is_disk_active;
         this.client_id = client_id;
         this.is_request_auth_code = is_request_auth_code;
         this.is_request_id_token = is_request_id_token;
+        this.is_request_email = is_request_email;
 
         this.is_supported = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(activity) == ConnectionResult.SUCCESS;
 
@@ -251,6 +253,12 @@ public class GpgsJNI {
             if (is_request_auth_code && client_id != null) {
                 builder.requestServerAuthCode(client_id);
             }
+
+            if (is_request_email) {
+                builder.requestEmail();
+            }
+            
+            builder.requestProfile();
 
             mSignInOptions = builder.build();
         }
@@ -335,6 +343,10 @@ public class GpgsJNI {
 
     public String getId() {
         return isLoggedIn() ? mPlayer.getPlayerId() : null;
+    }
+
+    public String getEmail() {
+        return isLoggedIn() ? mSignedInAccount.getEmail() : null;
     }
 
     public String getIdToken() {


### PR DESCRIPTION
Adds `request_email` and `request_profile` flag in gpgs config to be able to request these scopes from google. `gpgs.get_email()` and `gpg.get_profile()` function to retrieve these information.
* Fixes issue #48 