### PR TITLE
Update Google Play services dependencies

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,8 @@ Once the application is registered you also need to enable Google Play Game Serv
 
 ## Defold Setup
 
+The current Google Play services dependencies require Android 6.0 (API level 23) or newer. Set `android.minimum_sdk_version` to `23` or higher in `game.project`.
+
 Add the following section into your `game.project` file (open and edit as a text file):
 
 ```

--- a/game.project
+++ b/game.project
@@ -23,7 +23,7 @@ shared_state = 1
 
 [android]
 package = com.defold.extension.gpgs
-minimum_sdk_version = 21
+minimum_sdk_version = 23
 target_sdk_version = 34
 
 [ios]

--- a/gpgs/manifests/android/build.gradle
+++ b/gpgs/manifests/android/build.gradle
@@ -4,7 +4,6 @@ repositories {
 
 dependencies {
     // https://developers.google.com/android/guides/setup#split
-    implementation 'com.google.android.gms:play-services-base:18.5.0'
-    implementation 'com.google.android.gms:play-services-auth:21.3.0'
+    implementation 'com.google.android.gms:play-services-base:18.10.0'
     implementation 'com.google.android.gms:play-services-games-v2:21.0.0'
 }


### PR DESCRIPTION
## Summary

- update Google Play services Base from 18.5.0 to 18.10.0
- keep Play Games Services v2 at 21.0.0, which is still the current release used by the extension
- remove the unused Play Services Auth artifact
- raise and document the Android minimum API level to 23

## Why

Current Google Play services releases require Android API 23. The legacy Auth dependency is no longer needed by Play Games Services v2, and the extension does not import any APIs from that artifact, so retaining it only increases the dependency graph and risks avoidable version conflicts.

The Games v2 API remains at 21.0.0 because there is no newer compatible artifact to adopt. The release notes do not require an extension-side source migration for the Base update; the existing Games v2 integration remains compatible.

## Compatibility

This changes the Android minimum supported API level to 23, matching the requirement of the updated Play Services stack. No Lua or native extension API changes are introduced.

## Validation

- built the example project for Android with `/Users/agulev/Downloads/bob.jar` (Bob 1.13.1)
- validated both armv7 and arm64 native extension outputs
- build completed successfully against the production Defold Extender server
- `git diff --check` passed